### PR TITLE
Add release-branch CI config for 2.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add the `releaseBranch:` block to `enonic-gradle.yml` so the `2.x` maintenance branch can publish releases via the `enonic/release-tools/build-and-publish@master` action, alongside `master`.

This branch holds the XP 7 maintenance state (`xpVersion=7.0.0`, `version=2.1.1-SNAPSHOT`); no source/build changes here. The XP 8 upgrade lives on `master` in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)