### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,8 @@ plugins {
 dependencies {
     implementation xplibs.api.core
     implementation xplibs.api.portal
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.21.3'
-    implementation 'com.maxmind.db:maxmind-db:4.0.2'
+    implementation libs.jackson.databind
+    implementation libs.maxmind.db
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+jackson = "2.21.3"
+maxmind = "4.0.2"
+
+[libraries]
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+maxmind-db       = { module = "com.maxmind.db:maxmind-db",                   version.ref = "maxmind" }


### PR DESCRIPTION
## Summary

Migrates `lib-geoip` to use a Gradle TOML version catalog (`gradle/libs.versions.toml`). Pin-for-pin migration — no version bumps.

Conventions adopted (matching neighbouring catalogs):

- Version keys: short, lowercase, hyphen-separated.
- Library keys: same naming style, sorted alphabetically.
- `xpVersion` stays in `gradle.properties` (rest of the toolchain expects it there).
- `xplibs.*` accessors left unchanged.

## New catalog

```toml
[versions]
jackson = "2.21.3"
maxmind = "4.0.2"

[libraries]
jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
maxmind-db       = { module = "com.maxmind.db:maxmind-db",                   version.ref = "maxmind" }
```

## Verification

- `./gradlew clean build --refresh-dependencies` — green.
- `./gradlew dependencies --configuration runtimeClasspath` on this branch vs. master — byte-identical (only `BUILD SUCCESSFUL in Xms` line differs).

<sub>*Drafted with AI assistance*</sub>