### PR TITLE
Add @enonic-types/lib-geoip types package #64

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -2,6 +2,10 @@ name: Gradle Build
 
 on: [ push ]
 
+permissions:
+  id-token: write  # Required for npm OIDC / trusted publishing
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,6 +17,7 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          npmPublish: true
           releaseBranch: |
             master
             2.x

--- a/build.gradle
+++ b/build.gradle
@@ -16,3 +16,15 @@ repositories {
     mavenCentral()
     xp.enonicRepo()
 }
+
+// Assemble the @enonic-types/lib-geoip npm package (published on release by the CI npmPublish step).
+tasks.register('assembleTypes', Copy) {
+    from 'types'
+    into layout.buildDirectory.dir('types')
+    filesMatching('package.json') {
+        filter { line ->
+            line.replaceAll(/"version":\s*"[^"]*"/, "\"version\": \"${project.version}\"")
+        }
+    }
+}
+jar.dependsOn assembleTypes

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,104 @@
+declare module "/lib/geoip" {
+    export interface LocationNames {
+        en?: string;
+
+        [language: string]: string | undefined;
+    }
+
+    export interface ContinentInfo {
+        code?: string;
+        names?: LocationNames;
+        geoname_id?: number;
+    }
+
+    export interface CountryInfo {
+        iso_code?: string;
+        names?: LocationNames;
+        geoname_id?: number;
+    }
+
+    export interface CityInfo {
+        names?: LocationNames;
+        geoname_id?: number;
+    }
+
+    export interface LocationInfo {
+        latitude?: number;
+        longitude?: number;
+        time_zone?: string;
+        metro_code?: number;
+        accuracy_radius?: number;
+    }
+
+    export interface PostalInfo {
+        code?: string;
+    }
+
+    export interface SubdivisionInfo {
+        iso_code?: string;
+        names?: LocationNames;
+        geoname_id?: number;
+    }
+
+    export interface LocationData {
+        continent?: ContinentInfo;
+        country?: CountryInfo;
+        registered_country?: CountryInfo;
+        city?: CityInfo;
+        location?: LocationInfo;
+        postal?: PostalInfo;
+        subdivisions?: SubdivisionInfo[];
+    }
+
+    /**
+     * Gets location information from the database file at $XP_HOME/config/GeoLite2-City.mmdb.
+     *
+     * @param ip The IP address to get location data for. Falls back to the request's remote address when omitted or null.
+     * @returns Location data for the supplied IP, or `null` if the database is missing or the lookup fails.
+     */
+    export function getLocationData(ip?: string | null): LocationData | null;
+
+    /**
+     * Gets the name of the city from the locationData object.
+     *
+     * @param locationData The locationData object returned from `getLocationData`.
+     * @param language Language code the city name should be returned in. Defaults to `"en"`.
+     * @returns The name of the city, or `null` if unavailable. Falls back to English when the requested language is not present.
+     */
+    export function cityName(locationData: LocationData | null, language?: string): string | null;
+
+    /**
+     * Gets the name of the country from the locationData object.
+     *
+     * @param locationData The locationData object returned from `getLocationData`.
+     * @param language Language code the country name should be returned in. Defaults to `"en"`.
+     * @returns The name of the country, or `null` if unavailable. Falls back to English when the requested language is not present.
+     */
+    export function countryName(locationData: LocationData | null, language?: string): string | null;
+
+    /**
+     * Gets the ISO code of the country from the locationData object.
+     *
+     * @param locationData The locationData object returned from `getLocationData`.
+     * @returns The ISO code of the country, or `null` if unavailable.
+     */
+    export function countryISO(locationData: LocationData | null): string | null;
+
+    /**
+     * Gets the geo-location as latitude and longitude from the locationData object.
+     *
+     * @param locationData The locationData object returned from `getLocationData`.
+     * @returns The latitude and longitude in the format `"37.6534,-122.4231"`, or `null` if unavailable.
+     */
+    export function geoPoint(locationData: LocationData | null): string | null;
+
+    /**
+     * Runs a benchmark test with millions of random IP addresses. Results are only visible in the log.
+     *
+     * @param trace When `true`, logs JSON for one in every 100,000 IP addresses tested.
+     * @returns A string with the test complete message.
+     */
+    export function test(trace?: boolean): string;
+}
+
+export {};

--- a/types/package.json
+++ b/types/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@enonic-types/lib-geoip",
+  "version": "0.0.0",
+  "description": "Type definitions for the Enonic XP GeoIP library",
+  "types": "index.d.ts",
+  "files": [
+    "*"
+  ],
+  "keywords": [
+    "enonic",
+    "enonic-xp",
+    "lib-geoip",
+    "geoip",
+    "types",
+    "typescript"
+  ],
+  "license": "Apache-2.0",
+  "homepage": "https://github.com/enonic/lib-geoip#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/enonic/lib-geoip.git"
+  },
+  "bugs": {
+    "url": "https://github.com/enonic/lib-geoip/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@enonic-types/core": "^8.0.0"
+  }
+}


### PR DESCRIPTION
Publishes a TypeScript types package for lib-geoip so consumers get typed access to `/lib/geoip` (currently every consumer hand-authors ambient declarations — e.g. app-features shipped its own copy).

## Changes
- `types/index.d.ts` — ambient module declaration for `/lib/geoip`. Covers all six exports (`test`, `getLocationData`, `cityName`, `countryName`, `countryISO`, `geoPoint`) and the `LocationData` shape (continent, country, registered_country, city, location, postal, subdivisions), seeded from a proven declaration that already type-checks against real usage in app-features and mirrors the MaxMind GeoLite2-City payload documented in the README.
- `types/package.json` — `@enonic-types/lib-geoip` manifest (version substituted at build time; depends on `@enonic-types/core ^8.0.0`).
- `build.gradle` — `assembleTypes` Copy task builds `build/types` with `project.version` injected; `jar.dependsOn assembleTypes` (mirrors the pattern from enonic/lib-mustache#66; no node build needed for a pure-JS lib).
- `.github/workflows/enonic-gradle.yml` — `npmPublish: true` on `build-and-publish` + `id-token: write` / `contents: write` for OIDC trusted publishing.

## Verification
- `./gradlew build` green.
- `build/types/` contains `index.d.ts` + `package.json` with the substituted version (`3.1.0-SNAPSHOT`).
- The `.d.ts` type-checks cleanly against `@enonic-types/core ^8.0.0` when a consumer imports named exports and the `LocationData` type from `/lib/geoip` (verified in a scratch `tsc --strict` project).

**Note:** the first publish of a brand-new `@enonic-types/lib-geoip` needs the npm trusted-publisher / package access configured org-side. Depends on enonic/release-tools#71 (publish-only npmPublish) — merged.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)