### PR TITLE
GraalJS Compatibility #68

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     testImplementation "com.enonic.xp:testing:${xpVersion}"
     testImplementation libs.junit.jupiter
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testRuntimeOnly libs.graalvm.js
 }
 
 repositories {
@@ -22,18 +21,10 @@ repositories {
     xp.enonicRepo('dev')
 }
 
+xp {
+    scriptEngines = ['Nashorn', 'GraalJS']
+}
+
 test {
     useJUnitPlatform()
 }
-
-def testGraalJs = tasks.register('testGraalJs', Test) {
-    group = 'verification'
-    description = 'Runs tests with the GraalJS script engine.'
-    useJUnitPlatform()
-    testClassesDirs = sourceSets.test.output.classesDirs
-    classpath = sourceSets.test.runtimeClasspath
-    systemProperty 'xp.script-engine', 'GraalJS'
-    shouldRunAfter test
-}
-
-check.dependsOn testGraalJs

--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,30 @@ dependencies {
     implementation xplibs.api.portal
     implementation libs.jackson.databind
     implementation libs.maxmind.db
+
+    testImplementation "com.enonic.xp:testing:${xpVersion}"
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly libs.graalvm.js
 }
 
 repositories {
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo('dev')
 }
+
+test {
+    useJUnitPlatform()
+}
+
+def testGraalJs = tasks.register('testGraalJs', Test) {
+    group = 'verification'
+    description = 'Runs tests with the GraalJS script engine.'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    systemProperty 'xp.script-engine', 'GraalJS'
+    shouldRunAfter test
+}
+
+check.dependsOn testGraalJs

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,6 @@
 #
 group = com.enonic.lib
 projectName = lib-geoip
-xpVersion=8.0.2
+xpVersion=8.1.0-SNAPSHOT
 version=3.1.0-SNAPSHOT
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,11 @@
 [versions]
+graalvm = "25.0.3"
 jackson = "2.22.1"
+junit = "6.1.2"
 maxmind = "4.1.0"
 
 [libraries]
+graalvm-js       = { module = "org.graalvm.polyglot:js",                    version.ref = "graalvm" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+junit-jupiter    = { module = "org.junit.jupiter:junit-jupiter",             version.ref = "junit" }
 maxmind-db       = { module = "com.maxmind.db:maxmind-db",                   version.ref = "maxmind" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,9 @@
 [versions]
-graalvm = "25.0.3"
 jackson = "2.22.1"
 junit = "6.1.2"
 maxmind = "4.1.0"
 
 [libraries]
-graalvm-js       = { module = "org.graalvm.polyglot:js",                    version.ref = "graalvm" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
 junit-jupiter    = { module = "org.junit.jupiter:junit-jupiter",             version.ref = "junit" }
 maxmind-db       = { module = "com.maxmind.db:maxmind-db",                   version.ref = "maxmind" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.enonic.xp.settings' version '4.1.0'
+    id 'com.enonic.xp.settings' version '4.2.0'
 }
 
 rootProject.name = projectName

--- a/src/main/java/com/enonic/geoip/DbReader.java
+++ b/src/main/java/com/enonic/geoip/DbReader.java
@@ -1,116 +1,42 @@
 package com.enonic.geoip;
 
-/**
- * Created by Michael Lazell on 3/16/16.
- */
-
-import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.util.Map;
-import java.util.Objects;
 import java.util.function.Supplier;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.maxmind.db.CHMCache;
-import com.maxmind.db.Reader;
-import com.maxmind.db.Reader.FileMode;
 
-import com.enonic.xp.home.HomeDir;
 import com.enonic.xp.portal.PortalRequest;
 import com.enonic.xp.script.bean.BeanContext;
 import com.enonic.xp.script.bean.ScriptBean;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElseGet;
+
 public class DbReader
     implements ScriptBean
 {
-    private static final Logger LOG = LoggerFactory.getLogger( DbReader.class );
-
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
     private Supplier<PortalRequest> portalRequestSupplier;
 
-    private volatile Reader reader;
-
-    private File database;
-
-    private volatile long lastModified;
-
-    private Reader previousReader;
+    private DbReaderRegistry registry;
 
     public void init( final String databaseFilePath )
         throws IOException
     {
-        this.database =
-            new File( Objects.requireNonNullElse( databaseFilePath, HomeDir.get() + "/config/GeoLite2-City.mmdb" ) );
-
-        this.lastModified = this.database.lastModified();
-        this.reader = new Reader( this.database, FileMode.MEMORY_MAPPED, new CHMCache() );
+        this.registry.init( databaseFilePath );
     }
 
     public JsonNode getLocationDataFromFile( final String ip )
         throws IOException
     {
-        checkAndReload();
+        final String address = requireNonNullElseGet( ip, () -> portalRequestSupplier.get().getRemoteAddress() );
 
-        Reader localReader = Objects.requireNonNull( reader );
-
-        InetAddress ipa =
-            InetAddress.getByName( Objects.requireNonNullElseGet( ip, () -> portalRequestSupplier.get().getRemoteAddress() ) );
-
-        return OBJECT_MAPPER.valueToTree( localReader.get( ipa, Map.class ) );
-    }
-
-    private synchronized void checkAndReload()
-        throws IOException
-    {
-        if ( database == null )
-        {
-            return;
-        }
-        final long currentModified = database.lastModified();
-        if ( currentModified == 0 )
-        {
-            LOG.debug( "GeoIP database file is inaccessible: {}", database.getAbsolutePath() );
-            return;
-        }
-        if ( currentModified != lastModified )
-        {
-            final Reader newReader = new Reader( database, FileMode.MEMORY_MAPPED, new CHMCache() );
-            final Reader toClose = previousReader;
-            previousReader = reader;
-            this.lastModified = currentModified;
-            this.reader = newReader;
-            LOG.info( "GeoIP database reloaded from {}", database.getAbsolutePath() );
-            if ( toClose != null )
-            {
-                toClose.close();
-            }
-        }
-    }
-
-    public void dispose()
-        throws IOException
-    {
-        Reader local = reader;
-        if ( local != null )
-        {
-            local.close();
-        }
-        Reader prev = previousReader;
-        if ( prev != null )
-        {
-            prev.close();
-        }
+        return this.registry.getLocationData( address );
     }
 
     @Override
     public void initialize( final BeanContext context )
     {
         this.portalRequestSupplier = context.getBinding( PortalRequest.class );
+        this.registry = requireNonNull( context.getService( DbReaderRegistry.class ).get() );
     }
 }

--- a/src/main/java/com/enonic/geoip/DbReaderRegistry.java
+++ b/src/main/java/com/enonic/geoip/DbReaderRegistry.java
@@ -1,0 +1,106 @@
+package com.enonic.geoip;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.maxmind.db.CHMCache;
+import com.maxmind.db.Reader;
+import com.maxmind.db.Reader.FileMode;
+
+import com.enonic.xp.home.HomeDir;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
+
+@Component(immediate = true, service = DbReaderRegistry.class)
+public class DbReaderRegistry
+{
+    private static final Logger LOG = LoggerFactory.getLogger( DbReaderRegistry.class );
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private volatile Reader reader;
+
+    private File database;
+
+    private volatile long lastModified;
+
+    private Reader previousReader;
+
+    public synchronized void init( final String databaseFilePath )
+        throws IOException
+    {
+        if ( this.reader != null )
+        {
+            return;
+        }
+        this.database = new File( requireNonNullElse( databaseFilePath, HomeDir.get() + "/config/GeoLite2-City.mmdb" ) );
+        this.lastModified = this.database.lastModified();
+        this.reader = new Reader( this.database, FileMode.MEMORY_MAPPED, new CHMCache() );
+    }
+
+    public JsonNode getLocationData( final String ip )
+        throws IOException
+    {
+        checkAndReload();
+
+        final Reader localReader = requireNonNull( reader );
+
+        final InetAddress ipa = InetAddress.getByName( ip );
+
+        return OBJECT_MAPPER.valueToTree( localReader.get( ipa, Map.class ) );
+    }
+
+    private synchronized void checkAndReload()
+        throws IOException
+    {
+        if ( database == null )
+        {
+            return;
+        }
+        final long currentModified = database.lastModified();
+        if ( currentModified == 0 )
+        {
+            LOG.debug( "GeoIP database file is inaccessible: {}", database.getAbsolutePath() );
+            return;
+        }
+        if ( currentModified != lastModified )
+        {
+            final Reader newReader = new Reader( database, FileMode.MEMORY_MAPPED, new CHMCache() );
+            final Reader toClose = previousReader;
+            previousReader = reader;
+            this.lastModified = currentModified;
+            this.reader = newReader;
+            LOG.info( "GeoIP database reloaded from {}", database.getAbsolutePath() );
+            if ( toClose != null )
+            {
+                toClose.close();
+            }
+        }
+    }
+
+    @Deactivate
+    public void dispose()
+        throws IOException
+    {
+        Reader local = reader;
+        if ( local != null )
+        {
+            local.close();
+        }
+        Reader prev = previousReader;
+        if ( prev != null )
+        {
+            prev.close();
+        }
+    }
+}

--- a/src/main/resources/lib/geoip.js
+++ b/src/main/resources/lib/geoip.js
@@ -116,11 +116,3 @@ exports.geoPoint = function(locationData) {
     } catch (e) {}
     return null;
 };
-
-__.disposer(function() {
-    try {
-        dbBean.dispose();
-    } catch (e) {
-        log.debug('Can not close GeoIP database', e);
-    }
-});

--- a/src/test/java/com/enonic/geoip/GeoIpScriptLibTest.java
+++ b/src/test/java/com/enonic/geoip/GeoIpScriptLibTest.java
@@ -1,0 +1,21 @@
+package com.enonic.geoip;
+
+import com.enonic.xp.testing.ScriptRunnerSupport;
+
+public class GeoIpScriptLibTest
+    extends ScriptRunnerSupport
+{
+    @Override
+    protected void initialize()
+        throws Exception
+    {
+        super.initialize();
+        addService( DbReaderRegistry.class, new DbReaderRegistry() );
+    }
+
+    @Override
+    public String getScriptTestFile()
+    {
+        return "/lib/geoip-test.js";
+    }
+}

--- a/src/test/resources/lib/geoip-test.js
+++ b/src/test/resources/lib/geoip-test.js
@@ -1,0 +1,48 @@
+var geoLib = require('/lib/geoip');
+var assert = require('/lib/xp/testing');
+
+var sampleLocationData = {
+    city: {
+        names: {
+            en: 'Oslo',
+            no: 'Oslo'
+        }
+    },
+    country: {
+        iso_code: 'NO',
+        names: {
+            en: 'Norway',
+            no: 'Norge'
+        }
+    },
+    location: {
+        latitude: 59.5,
+        longitude: 10.75
+    }
+};
+
+exports.testGetLocationDataWithoutDatabase = function () {
+    assert.assertNull(geoLib.getLocationData('8.8.8.8'));
+};
+
+exports.testCityName = function () {
+    assert.assertEquals('Oslo', geoLib.cityName(sampleLocationData));
+    assert.assertEquals('Oslo', geoLib.cityName(sampleLocationData, 'no'));
+    assert.assertNull(geoLib.cityName(null));
+};
+
+exports.testCountryName = function () {
+    assert.assertEquals('Norway', geoLib.countryName(sampleLocationData));
+    assert.assertEquals('Norge', geoLib.countryName(sampleLocationData, 'no'));
+    assert.assertNull(geoLib.countryName(null));
+};
+
+exports.testCountryISO = function () {
+    assert.assertEquals('NO', geoLib.countryISO(sampleLocationData));
+    assert.assertNull(geoLib.countryISO(null));
+};
+
+exports.testGeoPoint = function () {
+    assert.assertEquals('59.5,10.75', geoLib.geoPoint(sampleLocationData));
+    assert.assertNull(geoLib.geoPoint(null));
+};


### PR DESCRIPTION
Fixes #68

## What

Moves the GeoIP database reader lifecycle off the JS module and onto the host side, following the same shape as enonic/lib-sql#154.

- **`DbReaderRegistry`** — a new OSGi `@Component(immediate = true, service = DbReaderRegistry.class)` that holds the single shared MaxMind `Reader` (plus the reload/`checkAndReload` state) and closes it from `@Deactivate dispose()`. The bundle lifecycle fires regardless of which context loaded the module, so the memory-mapped database is always closed.
- **`DbReader`** — now a thin `ScriptBean` that resolves `DbReaderRegistry` via `context.getService(...).get()`, so every script context shares **one** reader instead of creating one per context. It still holds the per-request `PortalRequest` binding to resolve the remote address.
- **`geoip.js`** — the `__.disposer(...)` call is removed. On pooled engines `__.disposer` is honored only from the bootstrap context (enonic/xp#12198); a library cannot control whether the consumer requires it from `main.js` or a controller.

## Why it isn't inert

The library jar contains **no** `OSGI-INF` descriptor — expected, because `-dsannotations` is set by `com.enonic.xp.app`, not `com.enonic.xp.base`. Verified with a throwaway app that `include`s the library; its jar contains:

```
Service-Component: OSGI-INF/com.enonic.geoip.DbReaderRegistry.xml

<scr:component ... name="com.enonic.geoip.DbReaderRegistry" immediate="true" deactivate="dispose">
  <service><provide interface="com.enonic.geoip.DbReaderRegistry"/></service>
  <implementation class="com.enonic.geoip.DbReaderRegistry"/>
</scr:component>
```

So the component activates, is resolvable as a service, and `dispose` runs on deactivation.

## Tests

Adds a dual-engine setup (`test` for Nashorn, `testGraalJs` for GraalJS, wired into `check`) and a `ScriptRunnerSupport` spec that exercises the library on both engines. Verified locally against a `8.1.0-SNAPSHOT` built from the enonic/xp#12198 branch: **5/5 tests pass on both Nashorn and GraalJS**.

## Draft

This needs the `ScriptRunnerSupport` fix from enonic/xp#12198, so it targets `xpVersion=8.1.0-SNAPSHOT` from `repo.enonic.com/dev`. **CI `testGraalJs` stays red until enonic/xp#12198 is merged and a fresh `8.1.0-SNAPSHOT` is published.** Opened as a draft for that reason.